### PR TITLE
check artifacts before publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,11 +21,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
+        twine check dist/*
         twine upload dist/*


### PR DESCRIPTION
The wheel failed to publish at 0.12 because of errors in the readme.

This pull request checks artifacts before attempting to publish.

Also switches to building using `build` - direct execution of `setup.py` is deprecated.

I leave it with you to fix the readme errors!